### PR TITLE
update fibers dep from v1 to v5 for node12

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "coffee-script": "~1.6.3",
-    "fibers": "~1.0.1",
+    "fibers": "^5.0.0",
     "lodash": "~2.2.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Updating node-make-sync to use fibers v5 so node12 can run it. This will be referenced in an upcoming change to node12/package.json, and be checked into codez (after being built in vagrant) underneath node12/node_modules